### PR TITLE
fix: add --no-sandbox flag so app launches in root/CI environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "start": "electron-vite preview",
-    "dev": "electron-vite dev",
+    "dev": "electron-vite dev -- --no-sandbox",
     "build": "electron-vite build",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "test": "vitest run",


### PR DESCRIPTION
Electron refuses to start as root without --no-sandbox. Added the flag to the dev script so npm run dev works in Docker/cloud/CI environments. No effect on normal desktop installs (Windows/Mac/Linux with own user).

Also adds CLAUDE.md with PR workflow and project instructions.

https://claude.ai/code/session_01FS7TNPWemK7wgagBzyBiTo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->