### PR TITLE
Add MiniMax as an LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ View the code for the node.
 
 ### LLM providers
 
-OpenAI, Anthropic (Claude), Google Gemini, Groq, xAI (Grok), OpenRouter, Ollama (local)
+OpenAI, Anthropic (Claude), Google Gemini, Groq, xAI (Grok), MiniMax, OpenRouter, Ollama (local)
 
 - API keys encrypted and stored locally via Electron `safeStorage` — never sent anywhere except the provider's own API
 - Test connection button per provider
@@ -252,6 +252,7 @@ API keys are encrypted and stored locally using Electron's `safeStorage`. They a
 | Google Gemini | [aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey) |
 | Groq | [console.groq.com/keys](https://console.groq.com/keys) |
 | xAI (Grok) | [console.x.ai](https://console.x.ai) |
+| MiniMax | [platform.minimaxi.com](https://platform.minimaxi.com) |
 | OpenRouter | [openrouter.ai/keys](https://openrouter.ai/keys) |
 | Ollama (local) | No key needed — install [Ollama](https://ollama.com) and pull a model |
 
@@ -274,7 +275,7 @@ ComfyNodeDesigner/
 │   │   ├── index.ts             # Window creation and IPC registration
 │   │   ├── ipc/
 │   │   │   ├── fileHandlers.ts  # Save/load/export/import — uses Electron dialogs + fs
-│   │   │   └── llmHandlers.ts   # All 7 LLM provider adapters with abort support
+│   │   │   └── llmHandlers.ts   # All 8 LLM provider adapters with abort support
 │   │   └── generators/
 │   │       ├── codeGenerator.ts # Python code generation logic
 │   │       └── nodeImporter.ts  # Python node pack parser (folder + file import)

--- a/src/main/ipc/llmHandlers.ts
+++ b/src/main/ipc/llmHandlers.ts
@@ -238,6 +238,8 @@ function getAdapter(req: LLMGenerateRequest, apiKey: string): LLMAdapter {
       return getGroqAdapter(apiKey)
     case 'xai':
       return getOpenAICompatibleAdapter(apiKey, req.baseUrl ?? 'https://api.x.ai/v1')
+    case 'minimax':
+      return getOpenAICompatibleAdapter(apiKey, req.baseUrl ?? 'https://api.minimax.io/v1')
     case 'openrouter':
       return getOpenAICompatibleAdapter(apiKey, req.baseUrl ?? 'https://openrouter.ai/api/v1')
     case 'ollama':

--- a/src/renderer/src/components/modals/SettingsModal.tsx
+++ b/src/renderer/src/components/modals/SettingsModal.tsx
@@ -20,7 +20,7 @@ interface SettingsModalProps {
   onClose: () => void
 }
 
-const PROVIDERS: LLMProvider[] = ['openai', 'anthropic', 'google', 'groq', 'xai', 'openrouter', 'ollama']
+const PROVIDERS: LLMProvider[] = ['openai', 'anthropic', 'google', 'groq', 'xai', 'minimax', 'openrouter', 'ollama']
 
 export function SettingsModal({ open, onClose }: SettingsModalProps): JSX.Element {
   const { llm, setProviderModel, setProviderBaseUrl, ollamaModels, fetchOllamaModels } = useSettingsStore()
@@ -152,8 +152,8 @@ export function SettingsModal({ open, onClose }: SettingsModalProps): JSX.Elemen
                     </div>
                   )}
 
-                  {/* Base URL (Ollama / OpenRouter / xAI) */}
-                  {(provider === 'ollama' || provider === 'openrouter' || provider === 'xai') && (
+                  {/* Base URL (Ollama / OpenRouter / xAI / MiniMax) */}
+                  {(provider === 'ollama' || provider === 'openrouter' || provider === 'xai' || provider === 'minimax') && (
                     <div className="space-y-1.5">
                       <Label className="text-xs text-slate-400">Base URL</Label>
                       <div className="flex gap-2">
@@ -165,7 +165,9 @@ export function SettingsModal({ open, onClose }: SettingsModalProps): JSX.Elemen
                               ? 'http://localhost:11434'
                               : provider === 'openrouter'
                                 ? 'https://openrouter.ai/api/v1'
-                                : 'https://api.x.ai/v1'
+                                : provider === 'minimax'
+                                  ? 'https://api.minimax.io/v1'
+                                  : 'https://api.x.ai/v1'
                           }
                           className="font-mono text-sm"
                         />

--- a/src/renderer/src/components/tabs/SettingsTab.tsx
+++ b/src/renderer/src/components/tabs/SettingsTab.tsx
@@ -14,7 +14,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { CheckCircle2, XCircle, Loader2, Eye, EyeOff, RefreshCw, X, Plus, ChevronDown, ChevronRight, Star } from 'lucide-react'
 import { cn } from '../../lib/utils'
 
-const PROVIDERS: LLMProvider[] = ['openai', 'anthropic', 'google', 'groq', 'xai', 'openrouter', 'ollama']
+const PROVIDERS: LLMProvider[] = ['openai', 'anthropic', 'google', 'groq', 'xai', 'minimax', 'openrouter', 'ollama']
 
 type SettingsSubTab = 'general' | 'color' | 'ai' | 'prompts'
 
@@ -409,8 +409,8 @@ function AIAssistantSubTab(): JSX.Element {
                 </div>
               )}
 
-              {/* Base URL (Ollama / OpenRouter / xAI) */}
-              {(provider === 'ollama' || provider === 'openrouter' || provider === 'xai') && (
+              {/* Base URL (Ollama / OpenRouter / xAI / MiniMax) */}
+              {(provider === 'ollama' || provider === 'openrouter' || provider === 'xai' || provider === 'minimax') && (
                 <div className="space-y-1.5">
                   <Label className="text-xs text-slate-400">Base URL</Label>
                   <div className="flex gap-2">
@@ -422,7 +422,9 @@ function AIAssistantSubTab(): JSX.Element {
                           ? 'http://localhost:11434'
                           : provider === 'openrouter'
                             ? 'https://openrouter.ai/api/v1'
-                            : 'https://api.x.ai/v1'
+                            : provider === 'minimax'
+                              ? 'https://api.minimax.io/v1'
+                              : 'https://api.x.ai/v1'
                       }
                       className="font-mono text-sm"
                     />

--- a/src/renderer/src/types/llm.types.ts
+++ b/src/renderer/src/types/llm.types.ts
@@ -4,6 +4,7 @@ export type LLMProvider =
   | 'google'
   | 'groq'
   | 'xai'
+  | 'minimax'
   | 'openrouter'
   | 'ollama'
 
@@ -68,6 +69,7 @@ export const DEFAULT_MODELS: Record<LLMProvider, string[]> = {
     'meta-llama/llama-4-scout-17b-16e-instruct'
   ],
   xai: ['grok-3', 'grok-3-mini', 'grok-2'],
+  minimax: ['MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
   openrouter: ['openai/gpt-5.4', 'anthropic/claude-sonnet-4-6', 'google/gemini-3.1-pro', 'meta-llama/llama-3.3-70b-instruct'],
   ollama: []  // Populated dynamically from local Ollama instance
 }
@@ -78,6 +80,7 @@ export const PROVIDER_LABELS: Record<LLMProvider, string> = {
   google: 'Google (Gemini)',
   groq: 'Groq',
   xai: 'xAI (Grok)',
+  minimax: 'MiniMax',
   openrouter: 'OpenRouter',
   ollama: 'Ollama (Local)'
 }
@@ -90,6 +93,7 @@ export const DEFAULT_LLM_SETTINGS: LLMSettings = {
     google: { provider: 'google', model: 'gemini-3.1-pro' },
     groq: { provider: 'groq', model: 'openai/gpt-oss-120b' },
     xai: { provider: 'xai', model: 'grok-3', baseUrl: 'https://api.x.ai/v1' },
+    minimax: { provider: 'minimax', model: 'MiniMax-M2.5', baseUrl: 'https://api.minimax.io/v1' },
     openrouter: {
       provider: 'openrouter',
       model: 'openai/gpt-5.4',


### PR DESCRIPTION
## Summary

Adds [MiniMax](https://platform.minimaxi.com) as a new LLM provider option, bringing the total from 7 to 8 supported providers.

MiniMax offers an OpenAI-compatible API with models like **MiniMax-M2.5** and **MiniMax-M2.5-highspeed**, featuring a 204K context window — well-suited for the multi-turn node logic generation this app does.

## Changes

- **Type definitions** (`llm.types.ts`): Added `'minimax'` to the `LLMProvider` union, `DEFAULT_MODELS`, `PROVIDER_LABELS`, and `DEFAULT_LLM_SETTINGS`
- **Provider adapter** (`llmHandlers.ts`): Added `'minimax'` case to the `getAdapter()` factory, reusing `getOpenAICompatibleAdapter` with MiniMax's base URL (`https://api.minimax.io/v1`)
- **Settings UI** (`SettingsTab.tsx`, `SettingsModal.tsx`): Added MiniMax to the `PROVIDERS` array and base URL input condition
- **README**: Added MiniMax to the provider list and API key table

## How it works

Since MiniMax exposes an OpenAI-compatible chat completions endpoint, no new SDK dependency is needed — the existing `getOpenAICompatibleAdapter()` handles everything with just the base URL override.

## Test plan

- [x] All 33 existing vitest tests pass
- [x] Production build (`npm run build`) succeeds
- [ ] Manual: enter a MiniMax API key in Settings → MiniMax, select a model, test connection
- [ ] Manual: use the AI assistant tab with MiniMax to generate node logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added MiniMax as a new supported LLM provider.
  * Two MiniMax models now available: MiniMax-M2.5 and MiniMax-M2.5-highspeed.
  * MiniMax provider configuration accessible in Settings with customizable Base URL support (default: https://api.minimax.io/v1).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->